### PR TITLE
fix: use useLayoutEffect instead of useEffect in useStorage to avoid the listeners being registered to late

### DIFF
--- a/src/storage/useStorage.ts
+++ b/src/storage/useStorage.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from "react";
+import {useCallback, useLayoutEffect, useMemo, useState} from "react";
 import {storage} from "./storage";
 
 export function useStorage<T>(key: string, defaultValue: T): [T, (newValue: T) => void] {
@@ -15,7 +15,7 @@ export function useStorage<T>(key: string, defaultValue: T): [T, (newValue: T) =
 		setValue(readStateFromStorage());
 	}, [readStateFromStorage]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		storage.addChangeListener(key, updateStateFromStorage);
 		return () => storage.removeChangeListener(key, updateStateFromStorage);
 	}, [key, updateStateFromStorage]);


### PR DESCRIPTION
## Coder

- [x] I paid attention to the warnings and errors the IDE gave me and I have fixed them where appropriate
- [ ] I wrote unit/integration tests where applicable
- [x] I tested that the issue is resolved
- [ ] I tested that no regressions were introduced (other features still work)
- [ ] I tested edge cases
- [ ] I tested error cases and errors are handled correctly
- [x] The build and tests have succeeded
- [ ] There are no conflicts with the main / master branch

## Reviewer

Code review:
- [ ] The coder completed their checklist to a reasonable extent (relative to the complexity of the PR)
- [ ] I have reviewed the code, and it is easy to understand and follows best practices.

Testing:
- [ ] I have tested that the issue is resolved
- [ ] I have tested that no regressions were introduced (other features still work)
- [ ] I have tested edge cases
- [ ] I have tested error cases and errors are handled correctly

Merging:
- [ ] I have resolved any database version conflicts
- [ ] The build and tests have succeeded
- [ ] I have moved the issue to *Waiting Deployment*
