### PR TITLE
feat(data-table): reset to first page when sort field changes

### DIFF
--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -14,7 +14,18 @@ import {
 	TableSortLabel,
 	useTheme,
 } from "@mui/material";
-import React, {ChangeEvent, FC, Fragment, Key, ReactElement, ReactNode, useCallback, useEffect, useState} from "react";
+import React, {
+	ChangeEvent,
+	FC,
+	Fragment,
+	Key,
+	ReactElement,
+	ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import {UndrawEmpty} from "../content-table/UndrawEmpty";
 import {ErrorAlert} from "../ErrorAlert";
 
@@ -140,6 +151,18 @@ export function DataTable<T>(props: Readonly<DataTableProps<T>>) {
 			}
 		}
 	}, [page, onPageChange]);
+
+	// reset page index to `0` when the sort field changes
+	// (direction-only toggles keep the user on the current page)
+	const previousSortField = useRef(sortField);
+	useEffect(() => {
+		if (previousSortField.current !== sortField) {
+			previousSortField.current = sortField;
+			if (page && onPageChange && page.pageIndex !== 0) {
+				onPageChange({...page, pageIndex: 0});
+			}
+		}
+	}, [sortField, page, onPageChange]);
 
 	// Reset selection when the rows change.
 	// In the future, we might add a mode where a selection can span across multiple pages


### PR DESCRIPTION
## Summary
- When the user changes the sort column in `<DataTable>`, `pageIndex` is reset to `0`. Page N under one sort has no relationship to page N under another, so staying put would just show arbitrary rows.
- Direction-only toggles (asc↔desc) intentionally **preserve** the current page, so users can flip ordering while exploring a specific page without being bounced to the top.
- Implemented in `DataTable` itself via a `useRef`-tracked `useEffect` on `sortField`, calling the existing `onPageChange` callback. No consumer changes required, regardless of how sort/page state is managed.

## Test plan
- [ ] Open a paginated `<DataTable>` demo, navigate to page 2+, click a different sortable column header → table jumps to page 1.
- [ ] Toggle sort direction (asc↔desc) on the same column from page 2+ → table stays on the current page.
- [ ] Verify no regression with the existing out-of-bounds reset (filter shrinks result set below current page).
- [ ] Verify behavior works for consumers using `useDataTableStorage` and consumers managing state manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)