### PR TITLE
fix(breadcrumbs): preserve container height when empty

### DIFF
--- a/src/breadcrumbs.tsx
+++ b/src/breadcrumbs.tsx
@@ -4,9 +4,10 @@ import React, {PropsWithChildren} from "react";
 import {ChevronRightIcon} from "./icons";
 
 export function Breadcrumbs({children}: PropsWithChildren<{}>) {
+	const hasChildren = React.Children.count(children) > 0;
 	return (
 		<MuiBreadcrumbs separator={<ChevronRightIcon fontSize="small" />}>
-			{children}
+			{hasChildren ? children : <Typography sx={{visibility: "hidden"}}>&nbsp;</Typography>}
 		</MuiBreadcrumbs>
 	);
 }


### PR DESCRIPTION
## Summary
- Render an invisible `Typography` placeholder inside `<Breadcrumbs>` when no children are passed, so the empty container matches the height of a populated one.
- Prevents layout shift in pages that toggle breadcrumbs in/out.

## Test plan
- [ ] Verify empty `<Breadcrumbs />` reserves the same vertical space as a populated trail in the demo app.
- [ ] Confirm populated `<Breadcrumbs>` rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)