### PR TITLE
fix(breadcrumbs): apply min-height to container

### DIFF
--- a/src/breadcrumbs.tsx
+++ b/src/breadcrumbs.tsx
@@ -4,10 +4,9 @@ import React, {PropsWithChildren} from "react";
 import {ChevronRightIcon} from "./icons";
 
 export function Breadcrumbs({children}: PropsWithChildren<{}>) {
-	const hasChildren = React.Children.count(children) > 0;
 	return (
-		<MuiBreadcrumbs separator={<ChevronRightIcon fontSize="small" />}>
-			{hasChildren ? children : <Typography sx={{visibility: "hidden"}}>&nbsp;</Typography>}
+		<MuiBreadcrumbs separator={<ChevronRightIcon fontSize="small" />} sx={{minHeight: 24}}>
+			{children}
 		</MuiBreadcrumbs>
 	);
 }


### PR DESCRIPTION
## Summary
- Set `minHeight: 24` on the `<MuiBreadcrumbs>` container so it reserves the same vertical space whether populated or empty.
- Replaces the previous placeholder approach, which relied on `React.Children.count` — that returns `>0` for `null`/`false` children, so common conditional patterns (`<Breadcrumbs>{cond && <Item/>}</Breadcrumbs>`) skipped the placeholder and the container collapsed.

## Test plan
- [ ] Verify empty `<Breadcrumbs />` reserves 24px of vertical space.
- [ ] Verify `<Breadcrumbs>{false}</Breadcrumbs>` and `<Breadcrumbs>{null}</Breadcrumbs>` also reserve 24px.
- [ ] Confirm populated `<Breadcrumbs>` rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)